### PR TITLE
fix: change provider value from constant to property

### DIFF
--- a/src/FlagdProvider.php
+++ b/src/FlagdProvider.php
@@ -16,7 +16,7 @@ use OpenFeature\interfaces\provider\ResolutionDetails;
 
 class FlagdProvider extends AbstractProvider implements Provider
 {
-    protected const NAME = 'FlagdProvider';
+    protected static string $NAME = 'FlagdProvider';
 
     private IConfig $config;
 


### PR DESCRIPTION
The implementation is not fulfilling the abstraction definition:
https://github.com/open-feature/php-sdk/blob/4e25be68937dc4ec405366cb6ba726f66fc0e5c8/src/implementation/provider/AbstractProvider.php#L19

```
protected static string $NAME = 'AbstractProvider';
```

The implementation is pointing not to a property but to a constant.

```
protected const NAME = 'SplitProvider';
```

This is leading to `getMetadata` method in the implementation to return all the time "AbstractProvider" value

**Reproducing the issues:**
```
<?php
abstract class AbstractProvider {
  protected static string $NAME = 'AbstractProvider';
  
  public function getMetadata()
  {
      return static::$NAME;
  }
}

class SplitProvider extends AbstractProvider
{
    protected const NAME = 'SplitProvider';
}

class FlagdProvider extends AbstractProvider
{
    protected const NAME = 'FlagdProvider';
}

$splitProvider = new SplitProvider();
var_dump($splitProvider->getMetadata());


$flagDProvider = new FlagdProvider();
var_dump($flagDProvider->getMetadata());
?>
```